### PR TITLE
destroyと子のコメントも一緒に削除

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -38,6 +38,12 @@ class PostsController < ApplicationController
     end
   end
 
+  def destroy
+    @post = Post.find(params[:id])
+    @post.destroy
+    redirect_to root_path, alert: "削除しました"
+  end
+
   private
   def post_params
     params.require(:post).permit(:title, :main, :Prefecture, :place, :person, :starttime, :money,user_id: current_user.id).merge(user_id: current_user.id) 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,5 +1,5 @@
 class Post < ApplicationRecord
   validates :title, :main, :Prefecture, :person, :starttime, :money, :user_id, presence: true
   belongs_to :user
-  has_many :comments
+  has_many :comments, dependent: :destroy
 end


### PR DESCRIPTION
# What
募集文の削除機能を実装
それに伴い、募集文に投稿されているコメントも一緒に削除

# Why
何らかの理由により、投稿した文を削除できるように。（予定が出来て中止したいなど）
コメントも一緒に削除されないとコメントがデータベース上にだけ保存されたままになってしまうため。