### PR TITLE
自分がコメントした物を見れるように

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -49,6 +49,12 @@ class PostsController < ApplicationController
     @searchtext = params[:search]
   end
 
+  def showcomments
+    @user = current_user.id
+    comments_post = Comment.where(user_id: "#{@user}").pluck(:post_id)
+    @posts = Post.where(id: comments_post )
+  end
+
   private
   def post_params
     params.require(:post).permit(:title, :main, :Prefecture, :place, :person, :starttime, :money,user_id: current_user.id).merge(user_id: current_user.id) 

--- a/app/views/layouts/_side.html.haml
+++ b/app/views/layouts/_side.html.haml
@@ -7,4 +7,5 @@
       = link_to prefecture_index_path, class:'tokyo' do
         地域別に探す
     %li.side__menu--wotch
+    = link_to showcomments_posts_path do
       過去閲覧

--- a/app/views/posts/_showcomments.html.haml
+++ b/app/views/posts/_showcomments.html.haml
@@ -1,0 +1,22 @@
+.indexmain
+  .indexmain__top
+    %br/
+    コメントした募集一覧
+  - @posts.each do |post|
+    .indexmain__top-block
+      = link_to post_path(post.id), class:'toplink' do
+        .indexmain__top-block-contenttitle
+          = post.title
+        .indexmain__top-block-contentuser
+          投稿者：
+          = post.user.name
+        .indexmain__top-block-contentprefecture
+          場所：
+          = post.Prefecture
+        .indexmain__top-block-contentperson
+          募集人数：
+          = post.person
+          人
+        .indexmain__top-block-contentstarttime
+          開始日時
+          = post.starttime.strftime("%Y-%m-%d %H:%M")

--- a/app/views/posts/showcomments.html.haml
+++ b/app/views/posts/showcomments.html.haml
@@ -1,0 +1,5 @@
+.wrapper
+  = render "layouts/header"
+  .wrapper__main
+    = render "layouts/side"
+    = render "showcomments"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
     resources :comments, only: [:create, :destroy]
     collection do
       get 'search'
+      get 'showcomments'
     end
   end
   


### PR DESCRIPTION
# What
自分が過去にコメントを投稿した募集記事一覧を見ることが出来るページを実装

# Why
コメントをしていくと自分がどこにコメントしたかを忘れてしまうため、一覧で見やすいように。
募集に「参加したい」とコメントしたがどこに書いたか忘れてしまってはマッチング率が低下し、サイトそのものの価値が薄れてしまうため。